### PR TITLE
Reset drivetrain when inactive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.12'
 
-    implementation 'com.github.Gongoliers:Library-of-Gongolierium:6.1.1'
+    implementation 'com.github.Gongoliers:Library-of-Gongolierium:6.1.2'
 }
 
 // Simulation configuration (e.g. environment variables).

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -4,8 +4,6 @@
 
 package frc.robot;
 
-import com.kylecorry.pid.PID;
-
 /**
  * The Constants class provides a convenient place for teams to hold robot-wide numerical or boolean
  * constants. This class should not be used for any other purpose. All constants should be declared
@@ -24,6 +22,9 @@ public final class Constants {
         public static final int kRightDriveCAN1 = 4;
         public static final int kRightDriveCAN2 = 5;
         public static final int kRightDriveCAN3 = 6;
+
+        // Inactivity
+        public static final double kInactivityThresholdSeconds = 1.0;
 
         // Voltage Regulation
         public static final double kNormalVoltage = 5.25;
@@ -54,7 +55,6 @@ public final class Constants {
     public static final double kRampUpSeconds = 0.5;
 
     public static final int kInterfaceMotorCANId = 0; // TODO: Configure
-    public static final int kRampUpSeconds = 2;
 
     public static final double kFeederMotorTargetSpeed = 0.55;
     public static final double kOuttakeMotorTargetSpeed = 0.45;

--- a/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DrivetrainSubsystem.java
@@ -88,6 +88,7 @@ public class DrivetrainSubsystem extends SubsystemBase {
         
         // Modular Drivetrain
         m_modularDrivetrain = ModularDrivetrain.from(m_drivetrain);
+        m_modularDrivetrain.setInactiveResetSeconds(DriveConstants.kInactivityThresholdSeconds);
         
         // Voltage Control Module 
         m_voltageControlModule = new VoltageControlModule(DriveConstants.kFastVoltage);


### PR DESCRIPTION
- Update Library of Gongolierium
- Reset drivetrain modules when inactive (i.e. when the robot is disabled)